### PR TITLE
Allow calling find without a filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,11 @@ Quickstart
     client = Client('<subdomain>', '<api_key>')
 
     Product = client.model('product.product')
+
+    # find products
+    some_products = Product.find()
+
+    # find products that have a name similar to iphone
     iphones = Product.find(['name', 'ilike', 'iphone'])
 
 

--- a/fulfil_client/client.py
+++ b/fulfil_client/client.py
@@ -112,7 +112,28 @@ class Model(object):
         )
 
     @json_response
-    def find(self, filter, page=1, per_page=10, fields=None, context=None):
+    def find(self, filter=None, page=1, per_page=10, fields=None, context=None):
+        """
+        Find records that match the filter.
+
+        Pro Tip: The fields could have nested fields names if the field is
+        a relationship type. For example if you were looking up an order
+        and also want to get the shipping address country then fields would be:
+
+            `['shipment_address', 'shipment_address.country']`
+
+        but country in this case is the ID of the country which is not very
+        useful if you don't already have a map. You can fetch the country code
+        by adding `'shipment_address.country.code'` to the fields.
+
+        :param filter: A domain expression (Refer docs for domain syntax)
+        :param page: The page to fetch to get paginated results
+        :param per_page: The number of records to fetch per page
+        :param fields: A list of field names to fetch.
+        :param context: Any overrides to the context.
+        """
+        if filter is None:
+            filter = []
         return self.client.session.get(
             self.path,
             params={

--- a/tests/test_fulfil_client.py
+++ b/tests/test_fulfil_client.py
@@ -19,6 +19,14 @@ def test_find(client):
     assert ir_models[0]['rec_name']
 
 
+def test_find_no_filter(client):
+    IRModel = client.model('ir.model')
+    ir_models = IRModel.find()
+    assert len(ir_models) > 0
+    assert ir_models[0]['id']
+    assert ir_models[0]['rec_name']
+
+
 def test_raises_server_error(client):
     Model = client.model('ir.model')
     with pytest.raises(ServerError):


### PR DESCRIPTION
Filter is optional and it is not reasonable to expect the user
to explicitly set the filter as `[]`. This change allows users
to provide no arguments to filter and still get a list of
records back.

Also updates the find method's documentation.
