### PR TITLE
Optimize reading value from cache

### DIFF
--- a/fulfil_client/model.py
+++ b/fulfil_client/model.py
@@ -540,10 +540,11 @@ class Model(object):
             return map(cls.from_cache, id)
 
         key = cls.get_cache_key(id)
+        cached_value = cls.cache_backend and cls.cache_backend.get(key)
 
-        if cls.cache_backend and cls.cache_backend.exists(key):
+        if cached_value:
             cache_logger.debug("HIT::%s" % key)
-            return cls(id=id, values=loads(cls.cache_backend.get(key)))
+            return cls(id=id, values=loads(cached_value))
 
         cache_logger.warn("MISS::%s" % key)
         record = cls(id=id)


### PR DESCRIPTION
Using direct 'get' over checking if key 'exists' and then 'get'

This fixes the following edge case:
  exists(key) == True
  -- µT --
  get(key) == None

[#134254553]