### PR TITLE
Handle empty multi cache lookups gracefully

### DIFF
--- a/fulfil_client/model.py
+++ b/fulfil_client/model.py
@@ -561,6 +561,8 @@ class Model(object):
                               include records that are not already in
                               cache.
         """
+        if not ids:
+            return []
         results = []
         misses = []
         if not cls.cache_backend:

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,6 @@ requirements = [
     'six',
 ]
 
-test_requirements = [
-    # TODO: put package test requirements here
-]
 
 setup(
     name='fulfil_client',
@@ -55,5 +52,5 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
+    tests_require=['pytest', 'redis'],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import os
 
 import pytest
+import redis
 
 from fulfil_client import Client
 from fulfil_client.model import model_base
@@ -16,3 +17,11 @@ def client():
 @pytest.fixture
 def Model(client):
     return model_base(client)
+
+
+@pytest.fixture
+def ModelWithCache(client):
+    return model_base(
+        client,
+        cache_backend=redis.StrictRedis(host='localhost', port=6379, db=0)
+    )


### PR DESCRIPTION
Redis does not like mget to be called with no arguments.