### PR TITLE
Add the ability to mock api for tests

### DIFF
--- a/fulfil_client/contrib/mock.py
+++ b/fulfil_client/contrib/mock.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class MockFulfil(object):
+    """
+    A Mock object that helps mock away the Fulfil API
+    for testing.
+    """
+    responses = []
+    models = {}
+
+    def __init__(self, target, responses=None):
+        self.target = target
+        self.reset_mocks()
+        if responses:
+            self.responses.extend(responses)
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.stop()
+        self.reset_mocks()
+        return type is None
+
+    def model(self, model_name):
+        return self.models.setdefault(
+            model_name, mock.MagicMock(name=model_name)
+        )
+
+    def start(self):
+        """
+        Start the patch
+        """
+        self._patcher = mock.patch(target=self.target)
+        MockClient = self._patcher.start()
+        instance = MockClient.return_value
+        instance.model.side_effect = mock.Mock(
+            side_effect=self.model
+        )
+
+    def stop(self):
+        """
+        End the patch
+        """
+        self._patcher.stop()
+
+    def reset_mocks(self):
+        """
+        Reset all the mocks
+        """
+        self.models = {}

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 pytest
 bumpversion
+mock

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 """Defines fixtures available to all tests."""
-import os
-
 import pytest
 import redis
 
@@ -11,13 +9,13 @@ from fulfil_client.model import model_base
 
 @pytest.fixture
 def client():
-    return Client('demo', os.environ['FULFIL_API_KEY'])
+    return Client('demo', 'test-api-key')
 
 
 @pytest.fixture
 def oauth_client():
     return Client(
-        'demo', auth=BearerAuth(os.environ['FULFIL_OAUTH_TOKEN'])
+        'demo', auth=BearerAuth('user-test-token')
     )
 
 

--- a/tests/test_mocking.py
+++ b/tests/test_mocking.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import pytest
+import fulfil_client
+from fulfil_client.contrib.mock import MockFulfil
+
+
+def api_calling_method():
+    client = fulfil_client.Client('apple', 'apples-api-key')
+    Product = client.model('product.product')
+    products = Product.search_read_all([], None, ['id'])
+    Product.write(
+        [p['id'] for p in products],
+        {'active': False}
+    )
+    return client
+
+
+def test_mock_1():
+    with MockFulfil('fulfil_client.Client') as mocked_fulfil:
+        Product = mocked_fulfil.model('product.product')
+        Product.search_read_all.return_value = [
+            {'id': 1},
+            {'id': 2},
+            {'id': 3},
+        ]
+
+        # Call the function
+        api_calling_method()
+
+        # Now assert
+        Product.search_read_all.assert_called()
+        Product.search_read_all.assert_called_with([], None, ['id'])
+        Product.write.assert_called_with(
+            [1, 2, 3], {'active': False}
+        )
+
+
+def test_mock_context():
+    "Ensure that old mocks die with the context"
+    with MockFulfil('fulfil_client.Client') as mocked_fulfil:
+        Product = mocked_fulfil.model('product.product')
+        api_calling_method()
+        Product.search_read_all.assert_called()
+
+    # Start new context
+    with MockFulfil('fulfil_client.Client') as mocked_fulfil:
+        Product = mocked_fulfil.model('product.product')
+        Product.search_read_all.assert_not_called()
+
+
+def test_mock_different_return_vals():
+    "Return different values based on mock side_effect"
+    def lookup_products(domain):
+        client = fulfil_client.Client('apple', 'apples-api-key')
+        Product = client.model('product.product')
+        return Product.search(domain)
+
+    def fake_search(domain):
+        # A fake search method that returns ids based on
+        # domain.
+        if domain == []:
+            return [1, 2, 3, 4, 5]
+        elif domain == [('salable', '=', True)]:
+            return [1, 2, 3]
+
+    with MockFulfil('fulfil_client.Client') as mocked_fulfil:
+        Product = mocked_fulfil.model('product.product')
+        Product.search.side_effect = fake_search
+        assert lookup_products([]) == [1, 2, 3, 4, 5]
+        assert lookup_products([('salable', '=', True)]) == [1, 2, 3]


### PR DESCRIPTION
This implements a convenient mocking api for testing Fulfil mock
api calls. Does not add mock as a dependency because it's part of stdlib
on python 3 and it's a contrib module where the user writing tests should
install mock if needed.

[FP-5166]