### PR TITLE
Make implementation of search_read_all more efficient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ requirements = [
     'money',
     'babel',
     'six',
+    'more-itertools',
 ]
 
 


### PR DESCRIPTION
Paginating through a database is more expensive for
large records sets. In this case, read all the ids
at once and then page through them locally and call
read with the ids instead.