### PR TITLE
Add a Kombu serialization entry point

### DIFF
--- a/fulfil_client/client.py
+++ b/fulfil_client/client.py
@@ -6,11 +6,11 @@ import logging
 from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime
-from functools import partial, wraps
+from functools import wraps
 
 import requests
 from more_itertools import chunked
-from .serialization import JSONDecoder, JSONEncoder
+from .serialization import dumps, loads
 from .exceptions import (
     UserError, ClientError, ServerError, AuthenticationError
 )
@@ -19,8 +19,6 @@ from .exceptions import Error  # noqa
 
 
 request_logger = logging.getLogger('fulfil_client.request')
-dumps = partial(json.dumps, cls=JSONEncoder)
-loads = partial(json.loads, object_hook=JSONDecoder())
 
 
 def json_response(function):

--- a/fulfil_client/contrib/kombu.py
+++ b/fulfil_client/contrib/kombu.py
@@ -8,10 +8,9 @@ https://docs.celeryproject.org
 
 This is used in setuptools to register custom endpoint
 """
-from fulfil_client.client import dumps, loads
+from fulfil_client.serialization import dumps, loads, CONTENT_TYPE
 
 
 register_args = (
-    dumps, loads,
-    'application/vnd.fulfil.v2+json', 'utf-8'
+    dumps, loads, CONTENT_TYPE, 'utf-8'
 )

--- a/fulfil_client/contrib/kombu.py
+++ b/fulfil_client/contrib/kombu.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""
+Serialization extension for Kombu, the underlying library
+used by Celery for asynchronous tasks.
+
+https://docs.celeryproject.org
+/projects/kombu/en/stable/userguide/serialization.html
+
+This is used in setuptools to register custom endpoint
+"""
+from fulfil_client.client import dumps, loads
+
+
+register_args = (
+    dumps, loads,
+    'application/vnd.fulfil.v2+json', 'utf-8'
+)

--- a/fulfil_client/serialization.py
+++ b/fulfil_client/serialization.py
@@ -2,11 +2,15 @@
 import datetime
 from decimal import Decimal
 from collections import namedtuple
+from functools import partial
 try:
     import simplejson as json
 except ImportError:
     import json
 import base64
+
+
+CONTENT_TYPE = 'application/vnd.fulfil.v2+json'
 
 
 class JSONDecoder(object):
@@ -147,3 +151,8 @@ JSONEncoder.register(
         '__class__': 'Decimal',
         'decimal': str(o),
     })
+
+
+
+dumps = partial(json.dumps, cls=JSONEncoder)
+loads = partial(json.loads, object_hook=JSONDecoder())

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,11 @@ setup(
         'fulfil_client': 'fulfil_client',
         'fulfil_client.contrib': 'fulfil_client/contrib'
     },
+    entry_points={
+        'kombu.serializers': [
+            'fulfil = fulfil_client.contrib.kombu:register_args',
+        ],
+    },
     include_package_data=True,
     install_requires=requirements,
     license="ISCL",


### PR DESCRIPTION
This can then be used by modules that have to use celery
or similar asyn task execution systems that need to serialize
Fulfil objects that include date objects.

The default json serialization is not capable of handling
commonly used fulfil data types like date, datetime and
Decimal.