### PR TITLE
Fix wizard create sending empty args list

### DIFF
--- a/fulfil_client/client.py
+++ b/fulfil_client/client.py
@@ -324,7 +324,7 @@ class Wizard(object):
         ctx.update(context or {})
         request_logger.debug("Wizard::%s.create" % (self.wizard_name,))
         rv = self.client.session.put(
-            self.path + "/create", dumps([]), params={"context": dumps(ctx)}
+            self.path + "/create", dumps([{}]), params={"context": dumps(ctx)}
         )
         # Call response signal
         return rv


### PR DESCRIPTION
Wizard.create() was sending an empty list [] as the request body, which caused an IndexError in the
server's rpc.convert() when it tried to pop the
context from args. Send [{}] instead so the server gets an empty context dict as expected.


```python
In [2]: from fulfil_client import Client

In [3]: client = Client("support-dk", api_key)

In [4]: Wizard = client.wizard("fulfil.email_template.send_
      ⋮ email")

In [5]: email_wizard = Wizard.create()

In [6]: print(email_wizard)
[18704, 'start', 'end']
```