### PR TITLE
Fix wizard methods sending context as query param instead of request body

### DIFF
--- a/fulfil_client/client.py
+++ b/fulfil_client/client.py
@@ -312,8 +312,7 @@ class Wizard(object):
         request_logger.debug("Wizard::%s.execute::%s" % (self.wizard_name, state))
         rv = self.client.session.put(
             self.path + "/execute",
-            dumps([session_id, data, state]),
-            params={"context": dumps(ctx)},
+            dumps([session_id, data, state, ctx]),
         )
         # Call response signal
         return rv
@@ -324,15 +323,16 @@ class Wizard(object):
         ctx.update(context or {})
         request_logger.debug("Wizard::%s.create" % (self.wizard_name,))
         rv = self.client.session.put(
-            self.path + "/create", dumps([{}]), params={"context": dumps(ctx)}
+            self.path + "/create", dumps([ctx]),
         )
         # Call response signal
         return rv
 
     @json_response
     def delete(self, session_id):
+        ctx = self.client.context.copy()
         request_logger.debug("Wizard::%s.delete" % (self.wizard_name,))
-        rv = self.client.session.put(self.path + "/delete", dumps([session_id]))
+        rv = self.client.session.put(self.path + "/delete", dumps([session_id, ctx]))
         # Call response signal
         return rv
 


### PR DESCRIPTION
The server's rpc.convert expects context as the last element of the request body args list. When context is missing from the body, it pops the last positional arg (e.g. state_name string) and tries to call .pop() on it, causing AttributeError: 'str' object has no attribute 'pop'.

This affected execute (always crashes) and delete (would crash if called). create only worked by coincidence since its body was [{}] — a dict.