### PR TITLE
Use HTTP QUERY instead of PUT for read RPC methods

### DIFF
--- a/fulfil_client/client.py
+++ b/fulfil_client/client.py
@@ -8,20 +8,20 @@ from datetime import datetime
 from functools import wraps
 
 import requests
+from more_itertools import chunked
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
-from more_itertools import chunked
-from .serialization import dumps, loads
-from .exceptions import (
-    UserError,
-    ClientError,
-    ServerError,
-    AuthenticationError,
-    RateLimitError,
-)
-from .signals import response_received
-from .exceptions import Error  # noqa
 
+from .exceptions import (
+    AuthenticationError,
+    ClientError,
+    Error,  # noqa
+    RateLimitError,
+    ServerError,
+    UserError,
+)
+from .serialization import dumps, loads
+from .signals import response_received
 
 request_logger = logging.getLogger("fulfil_client.request")
 
@@ -322,9 +322,7 @@ class Wizard(object):
         ctx = self.client.context.copy()
         ctx.update(context or {})
         request_logger.debug("Wizard::%s.create" % (self.wizard_name,))
-        rv = self.client.session.put(
-            self.path + "/create", dumps([ctx]),
-        )
+        rv = self.client.session.put(self.path + "/create", dumps([ctx]))
         # Call response signal
         return rv
 
@@ -371,9 +369,15 @@ class Model(object):
             request_logger.debug(
                 "%s.%s::%s::%s" % (self.model_name, name, args, kwargs)
             )
-            rv = self.client.session.put(
+            http_method = (
+                "QUERY"
+                if name in ("search", "read", "search_read", "search_count")
+                else "PUT"
+            )
+            rv = self.client.session.request(
+                http_method,
                 self.path + "/%s" % name,
-                dumps(args),
+                data=dumps(args),
                 params={
                     "context": dumps(context),
                 },

--- a/fulfil_client/serialization.py
+++ b/fulfil_client/serialization.py
@@ -1,8 +1,9 @@
 # -*- coding: UTF-8 -*-
 import datetime
-from decimal import Decimal
 from collections import namedtuple
+from decimal import Decimal
 from functools import partial
+
 import isodate
 
 try:
@@ -10,7 +11,6 @@ try:
 except ImportError:
     import json
 import base64
-
 
 CONTENT_TYPE = "application/vnd.fulfil.v3+json"
 
@@ -79,7 +79,7 @@ def timedelta_decoder(v):
 
 @register_decoder("bytes")
 def _bytes_decoder(v):
-    cast = bytearray if bytes == str else bytes
+    cast = bytearray if bytes is str else bytes
     return cast(base64.decodebytes(v["base64"].encode("utf-8")))
 
 


### PR DESCRIPTION
Read-oriented RPC calls (search, read, search_read, search_count) need a request body to carry filters and fields, so they were sent as PUT — a method HTTP treats as unsafe and non-idempotent even though these calls never mutate data. With no safe, idempotent method that permits a body, read-with-body had to piggyback on PUT, mislabeling read traffic to proxies, caches, and retry logic.

[sc-105627]